### PR TITLE
Potential fix for jittery tooltips

### DIFF
--- a/js/d3.tip.v0.6.3.js
+++ b/js/d3.tip.v0.6.3.js
@@ -35,7 +35,7 @@ d3.tip = function() {
         coords
 
     nodel.html(content)
-      .style({ opacity: 1, 'pointer-events': 'all' })
+      .style({ opacity: 1 })
 
     while(i--) nodel.classed(directions[i], false)
     coords = direction_callbacks.get(dir).apply(this)


### PR DESCRIPTION
As far as I can tell the d3-tips module is setting sets ```'pointer-events': 'all'```. Since the tooltip appears in front of the underlying display, any movement in the body of the tooltip will be considered a mouse-off event causing the tooltip to go back into hiding. Unless there are mouse events associated with the tooltips there's no real reason to turn this on.

This code has not been tested since I only diagnosed the bug on the demo website and have not run the software myself.